### PR TITLE
Update Twitter links

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,7 @@
         },
         "default_title": "Upload to Danbooru",
         "show_matches": [
-            "https://twitter.com/*/status/*",
+            "https://x.com/*/status/*",
             "https://twitpic.com/*",
 
             "https://www.pixiv.net/artworks/*",

--- a/test/test_uploadToDanbooru.js
+++ b/test/test_uploadToDanbooru.js
@@ -21,7 +21,7 @@ describe("UploadToDanbooru", function() {
         "minimum_chrome_version": "97",
         "action": {
             "show_matches": [
-                "https://twitter.com/*/status/*",
+                "https://x.com/*/status/*",
                 "https://www.pixiv.net/artworks/*",
                 "https://*.tumblr.com/post/*",
             ],

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -9,13 +9,13 @@ import {
 describe("getPageActionMatchRegExp()", function() {
     it("", function() {
         const globs = [
-            "https://twitter.com/*/status/*",
+            "https://x.com/*/status/*",
             "https://www.pixiv.net/artworks/*",
             "https://*.tumblr.com/post/*",
         ];
         const result = getPageActionMatchRegExp(globs);
 
-        should(result).equal("^https://twitter\\.com/.*/status/.*|^https://www\\.pixiv\\.net/artworks/.*|^https://.*\\.tumblr\\.com/post/.*");
+        should(result).equal("^https://x\\.com/.*/status/.*|^https://www\\.pixiv\\.net/artworks/.*|^https://.*\\.tumblr\\.com/post/.*");
     });
 });
 


### PR DESCRIPTION
https://twitter.com/ now redirects to https://x.com/.

Because of that, the extension has partially stopped working on X, as the new domain has never been added to the code.